### PR TITLE
[ADD] ver3.0 - 동적 이진화

### DIFF
--- a/wrap-up/.gitignore
+++ b/wrap-up/.gitignore
@@ -17,3 +17,4 @@
 # video, result
 **/video/*
 **/result/*
+/*/build

--- a/wrap-up/profile/oneVideoWriter.hpp
+++ b/wrap-up/profile/oneVideoWriter.hpp
@@ -39,7 +39,7 @@ OneVideoWriter::OneVideoWriter(std::string file_path, int width, int height, int
     this->col = col;
     this->proc_cnt = proc_cnt;
 
-    vw.open(file_path, cv::VideoWriter::fourcc('a', 'v', 'c', '1'), 30, cv::Size(col * width, row * height), true);
+    vw.open(file_path, cv::VideoWriter::fourcc('p', 'n', 'g', ' '), 30, cv::Size(col * width, row * height), true);
     this->merged_frame = cv::Mat(row * height, col * width, CV_8UC3);
 }
 

--- a/wrap-up/ver3.0/CMakeLists.txt
+++ b/wrap-up/ver3.0/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.18.4)
+project(ver3_0)
+
+set(CMAKE_CXX_STANDARD 14)
+find_package(OpenCV)
+include_directories(${OpenCV_INCLUDE_DIRS})
+
+
+add_executable(ver3_0
+        main.cpp
+        )
+
+target_link_libraries(ver3_0 ${OpenCV_LIBS})

--- a/wrap-up/ver3.0/ROI.hpp
+++ b/wrap-up/ver3.0/ROI.hpp
@@ -74,8 +74,8 @@ void ROI::updateAdaptiveMask(int pos) {
     polygon.assign({
                            {avg.x_bottom - DX, DEFAULT_ROI_HEIGHT},
                            {avg.x_bottom + DX, DEFAULT_ROI_HEIGHT},
-                           {avg.x_top + DX,    0},
-                           {avg.x_top - DX,    0}
+                           {avg.x_top + DX, 0},
+                           {avg.x_top - DX, 0}
                    });
     cv::fillPoly(this->ROI_mask[pos], polygon, 255);
 }

--- a/wrap-up/ver3.0/ROI.hpp
+++ b/wrap-up/ver3.0/ROI.hpp
@@ -1,0 +1,102 @@
+#ifndef VER3_0_ROI_HPP
+#define VER3_0_ROI_HPP
+
+#include <iostream>
+#include <opencv2/opencv.hpp> // Mat, fillPoly, bitwise_and,
+#include <vector>
+#include "./latestInfo.hpp"
+
+class ROI {
+public:
+    // 좌우 하나씩
+    cv::Mat default_mask[2];
+    cv::Mat ROI_mask[2];
+    LatestInfo line_info[2];
+
+    ROI();
+
+    void initROI(int pos);
+
+    void updateAdaptiveMask(int pos);
+
+    void applyROI(cv::InputArray frame, cv::OutputArray result);
+
+    void updateROI();
+
+};
+
+/**
+ * 기본 생성자
+ */
+ROI::ROI() {
+    for (int i = 0; i < 2; i++) {
+        this->default_mask[i] = cv::Mat::zeros(DEFAULT_ROI_HEIGHT, DEFAULT_ROI_WIDTH, CV_8U);
+    }
+
+    this->default_mask[0](cv::Range(0, DEFAULT_ROI_HEIGHT), cv::Range(0, DEFAULT_ROI_CENTER - DEFAULT_ROI_LEFT)).setTo(
+            255);
+    this->default_mask[1](cv::Range(0, DEFAULT_ROI_HEIGHT),
+                          cv::Range(DEFAULT_ROI_CENTER - DEFAULT_ROI_LEFT, DEFAULT_ROI_WIDTH)).setTo(255);
+
+    for (int i = 0; i < 2; i++) {
+        line_info[i].reset();
+        initROI(i);
+    }
+}
+
+/**
+ * roi 초기화 (정적 roi로 설정)
+ */
+void ROI::initROI(int pos) {
+    this->ROI_mask[pos] = this->default_mask[pos].clone();
+}
+
+/**
+ * roi mask를 프레임에 적용
+ * @param frame 1채널 이미지
+ * @param result 결과 받아갈 이미지
+ */
+void ROI::applyROI(cv::InputArray frame, cv::OutputArray result) {
+    cv::Mat mask;
+    cv::bitwise_or(this->ROI_mask[0], this->ROI_mask[1], mask);
+    cv::bitwise_and(frame, mask, result);
+}
+
+/**
+ * latest_info를 이용해서 동적 마스킹 영역 갱신
+ */
+void ROI::updateAdaptiveMask(int pos) {
+    // 동적 roi mask 갱신
+    this->ROI_mask[pos] = cv::Mat::zeros(DEFAULT_ROI_HEIGHT, DEFAULT_ROI_WIDTH, CV_8U);
+    Line_info avg = line_info[pos].line;
+    std::vector <cv::Point> polygon;
+
+    polygon.assign({
+                           {avg.x_bottom - DX, DEFAULT_ROI_HEIGHT},
+                           {avg.x_bottom + DX, DEFAULT_ROI_HEIGHT},
+                           {avg.x_top + DX,    0},
+                           {avg.x_top - DX,    0}
+                   });
+    cv::fillPoly(this->ROI_mask[pos], polygon, 255);
+}
+
+/**
+ * roi 갱신
+ * - 정적 -> 동적: 동적 roi 갱신
+ * - 동적 유지: 동적 roi 갱신 (직전에 업데이트가 일어나지 않았다면 continue 하는 조건 추가 예정)
+ * - 동적 -> 정적: roi 초기화 및 line_info(latest_info) 초기화
+ */
+void ROI::updateROI() {
+    for (int i = 0; i < 2; i++) {
+        // 1. 정적 roi 리셋이 필요한 경우
+        if (this->line_info[i].undetected_cnt == UNDETECTED_STD) {
+            this->line_info[i].reset();
+            this->initROI(i);
+        } else if (this->line_info[i].undetected_cnt == 0 && this->line_info[i].adaptive_ROI_flag) {
+            // 2. 동적 roi 갱신
+            this->updateAdaptiveMask(i);
+        }
+    }
+}
+
+#endif //VER3_0_ROI_HPP

--- a/wrap-up/ver3.0/adaptiveThresh.hpp
+++ b/wrap-up/ver3.0/adaptiveThresh.hpp
@@ -1,0 +1,64 @@
+#ifndef VER3_0_ADAPTIVETHRESH_HPP
+#define VER3_0_ADAPTIVETHRESH_HPP
+
+#include "opencv2/opencv.hpp"
+#include "./constant.hpp"
+
+/**
+ * 동적 이진화 v1.0
+ */
+class AdaptiveThresh {
+public:
+    int thresh;
+
+    AdaptiveThresh() {
+        this->thresh = 150;
+    }
+
+    void applyThresholding(cv::InputArray src, cv::OutputArray dst);
+
+    int updateThresholding(cv::InputArray src);
+};
+
+/**
+ * 기존 thresholding 함수 대체 -> 호출 시점에 조정된 thresh 값으로 이진화
+ * @param src
+ * @param dst
+ */
+void AdaptiveThresh::applyThresholding(cv::InputArray src, cv::OutputArray dst) {
+    threshold(src, dst, this->thresh, 145, cv::THRESH_BINARY);
+
+}
+
+/**
+ * 이진화 값 조정하는 함수
+ * @param src 이진화 된 프레임
+ * @return 전체 픽셀 중 하얗게 표기 된 픽셀 수
+ */
+int AdaptiveThresh::updateThresholding(cv::InputArray src) {
+    cv::Mat frame = src.getMat();
+    int white = 0;
+    for (int i = 0; i < DEFAULT_ROI_HEIGHT; i++) {
+        uchar *ptr = frame.ptr<uchar>(i);
+        for (int j = 0; j < DEFAULT_ROI_WIDTH; j++) {
+            if (ptr[j]) white++;
+        }
+    }
+
+#ifdef THRESH_DEBUG
+    std::cout << this->thresh << ' ' << (double) white / (DEFAULT_ROI_HEIGHT * DEFAULT_ROI_WIDTH) * 100 << ' ';
+#endif
+    // 5% 초과 혹은 1% 미만일 경우 임계치 조정
+    if (white > DEFAULT_ROI_HEIGHT * DEFAULT_ROI_WIDTH * 0.05) {
+        this->thresh += 5;
+    } else if (white < DEFAULT_ROI_HEIGHT * DEFAULT_ROI_WIDTH * 0.01) {
+        this->thresh -= 5;
+    }
+
+#ifdef THRESH_DEBUG
+    std::cout << this->thresh << '\n';
+#endif
+    return white;
+}
+
+#endif //VER3_0_ADAPTIVETHRESH_HPP

--- a/wrap-up/ver3.0/adaptiveThresh.hpp
+++ b/wrap-up/ver3.0/adaptiveThresh.hpp
@@ -10,9 +10,11 @@
 class AdaptiveThresh {
 public:
     int thresh;
+    int white;
 
     AdaptiveThresh() {
         this->thresh = 150;
+        this->white = 0;
     }
 
     void applyThresholding(cv::InputArray src, cv::OutputArray dst);
@@ -37,28 +39,22 @@ void AdaptiveThresh::applyThresholding(cv::InputArray src, cv::OutputArray dst) 
  */
 int AdaptiveThresh::updateThresholding(cv::InputArray src) {
     cv::Mat frame = src.getMat();
-    int white = 0;
+    int new_white = 0;
     for (int i = 0; i < DEFAULT_ROI_HEIGHT; i++) {
         uchar *ptr = frame.ptr<uchar>(i);
         for (int j = 0; j < DEFAULT_ROI_WIDTH; j++) {
-            if (ptr[j]) white++;
+            if (ptr[j]) new_white++;
         }
     }
+    this->white = new_white;
 
-#ifdef THRESH_DEBUG
-    std::cout << this->thresh << ' ' << (double) white / (DEFAULT_ROI_HEIGHT * DEFAULT_ROI_WIDTH) * 100 << ' ';
-#endif
     // 5% 초과 혹은 1% 미만일 경우 임계치 조정
-    if (white > DEFAULT_ROI_HEIGHT * DEFAULT_ROI_WIDTH * 0.05) {
+    if (this->white > DEFAULT_ROI_HEIGHT * DEFAULT_ROI_WIDTH * 0.05) {
         this->thresh += 5;
-    } else if (white < DEFAULT_ROI_HEIGHT * DEFAULT_ROI_WIDTH * 0.01) {
+    } else if (this->white < DEFAULT_ROI_HEIGHT * DEFAULT_ROI_WIDTH * 0.01) {
         this->thresh -= 5;
     }
-
-#ifdef THRESH_DEBUG
-    std::cout << this->thresh << '\n';
-#endif
-    return white;
+    return this->white;
 }
 
 #endif //VER3_0_ADAPTIVETHRESH_HPP

--- a/wrap-up/ver3.0/constant.hpp
+++ b/wrap-up/ver3.0/constant.hpp
@@ -1,0 +1,29 @@
+#ifndef VER3_0_CONSTANT_HPP
+#define VER3_0_CONSTANT_HPP
+
+// 영상 정보
+#define FRAME_WIDTH 640
+#define FRAME_HEIGHT 360
+#define FRAME_ROWS FRAME_HEIGHT
+#define FRAME_COLS FRAME_WIDTH
+
+// roi 설정 값
+#define DX 15 // 2*DX = 동적 ROi 폭
+#define DEFAULT_ROI_LEFT 100 // ROI 좌측 x값
+#define DEFAULT_ROI_RIGHT 540 // ROI 우측 x값
+#define DEFAULT_ROI_UP 195 // ROI 상단 y값
+#define DEFAULT_ROI_DOWN 284 // ROI 하단 y값
+#define DEFAULT_ROI_CENTER 320
+#define DEFAULT_ROI_HEIGHT (DEFAULT_ROI_DOWN - DEFAULT_ROI_UP) // ROI 높이
+#define DEFAULT_ROI_WIDTH (DEFAULT_ROI_RIGHT - DEFAULT_ROI_LEFT)
+// 기타 변수
+#define GRADIENT_STD 2 // cotanent(30 deg) = 1.73
+
+// MODE
+//#define SHOW //imshow  활성화
+#define TIME_TEST // 출력 문구
+//#define GRAPHIC
+//#define VIDEO_SAVE
+//#define DETECTION_RATE
+
+#endif //VER3_0_CONSTANT_HPP

--- a/wrap-up/ver3.0/constant.hpp
+++ b/wrap-up/ver3.0/constant.hpp
@@ -25,5 +25,6 @@
 //#define GRAPHIC
 //#define VIDEO_SAVE
 //#define DETECTION_RATE
+//#define THRESH_DEBUG
 
 #endif //VER3_0_CONSTANT_HPP

--- a/wrap-up/ver3.0/constant.hpp
+++ b/wrap-up/ver3.0/constant.hpp
@@ -19,6 +19,10 @@
 // 기타 변수
 #define GRADIENT_STD 2 // cotanent(30 deg) = 1.73
 
+#define HOUGH_PARAM1 30
+#define HOUGH_PARAM2 40
+#define HOUGH_PARAM3 40
+
 // MODE
 //#define SHOW //imshow  활성화
 #define TIME_TEST // 출력 문구

--- a/wrap-up/ver3.0/latestInfo.hpp
+++ b/wrap-up/ver3.0/latestInfo.hpp
@@ -1,0 +1,79 @@
+#ifndef VER3_0_LATESTINFO_HPP
+#define VER3_0_LATESTINFO_HPP
+
+#include <iostream>
+#include "./constant.hpp"
+
+#define QUE_MAX_SIZE 5
+#define UNDETECTED_STD 5
+
+struct Line_info {
+    int x_bottom, x_top;
+    double gradient;
+};
+
+class LatestInfo {
+public:
+    int undetected_cnt;             // 연속으로 선분을 찾지 못한 프레임의 수
+    int que_length;                 // 큐에 들어있는 프레임의 수
+    bool adaptive_ROI_flag;         // 동적 roi 플래그 표시
+    Line_info line;
+
+    void update_lines(cv::Point p1, cv::Point p2, double gradient);  // 차선 정보 갱신
+//    Avg get_prev();                    // x 좌표와 기울기의 평균 반환
+    void print_all();                 // 정보 출력 - 디버깅용
+    void not_found();                 // 차선 미발견
+    void reset();                     // 초기 실행시, 혹은 반복문 초입에서
+};
+
+void LatestInfo::update_lines(cv::Point p1, cv::Point p2, double gradient) {
+    // 차선을 찾은 경우 - reset undetected_cnt
+    this->undetected_cnt = 0;
+
+    int x1 = (p1.x * (p2.y - DEFAULT_ROI_HEIGHT) - p2.x * (p1.y - DEFAULT_ROI_HEIGHT)) / (p2.y - p1.y);
+    int x2 = x1 - DEFAULT_ROI_HEIGHT * gradient;
+
+    if (this->que_length == 0) {
+        this->line = {x1, x2, gradient};
+        this->que_length++;
+        return;
+    }
+    // 정보 갱신
+    this->line.x_bottom = (4 * this->line.x_bottom + x1) / 5;
+    this->line.x_top = (4 * this->line.x_top + x2) / 5;
+    this->line.gradient = (4 * this->line.gradient + gradient) / 5;
+
+    // 적응형 roi on
+    if (!this->adaptive_ROI_flag && ++(this->que_length) == QUE_MAX_SIZE) {
+        this->adaptive_ROI_flag = true;
+    }
+}
+
+// 변경 -> 리셋 부분은 ROI에서 관리 - 좌우 차선의 리셋 지점을 맞춰주기 위함
+void LatestInfo::not_found() {
+    this->undetected_cnt++;
+}
+
+/**
+ * 프린트
+ */
+void LatestInfo::print_all() {
+    printf("undetected_cnt: %d\n", this->undetected_cnt);
+    printf("que_length: %d\n", this->que_length);
+    printf("undetected_cnt: %d\n", this->adaptive_ROI_flag);
+
+    printf("|%10s|%10s|%10s\n", "x_bottom", "x_top", "grad");
+    printf("|%10d|%10d|%10f\n", this->line.x_bottom, this->line.x_top, this->line.gradient);
+}
+
+/**
+ * 초기화 하는 함수
+ */
+void LatestInfo::reset() {
+    this->undetected_cnt = 0;
+    this->que_length = 0;
+    this->adaptive_ROI_flag = false;
+    this->line = {0, 0, 0};
+}
+
+#endif //VER3_0_LATESTINFO_HPP

--- a/wrap-up/ver3.0/latestInfo.hpp
+++ b/wrap-up/ver3.0/latestInfo.hpp
@@ -5,7 +5,7 @@
 #include "./constant.hpp"
 
 #define QUE_MAX_SIZE 5
-#define UNDETECTED_STD 5
+#define UNDETECTED_STD 10
 
 struct Line_info {
     int x_bottom, x_top;

--- a/wrap-up/ver3.0/main.cpp
+++ b/wrap-up/ver3.0/main.cpp
@@ -58,7 +58,7 @@ double getCotangent(Point p1, Point p2) {
 void drawLines(InputOutputArray frame, const std::vector<Vec4i> &lines, Scalar color = Scalar(0, 255, 0)) {
     for (Vec4i pts: lines) {
         Point p1(pts[0], pts[1]), p2(pts[2], pts[3]);
-        line(frame, p1, p2, color, 1, 8);
+        line(frame, p1, p2, color, 1, LINE_AA);
     }
 }
 
@@ -99,7 +99,7 @@ void filterLinesWithAdaptiveROI(InputOutputArray frame, const std::vector<Vec4i>
 
         if (abs(m) > GRADIENT_STD) { // 기준 기울기보다 작은 경우 (역수로 계산하므로 부등호 반대)
 #ifdef GRAPHIC
-            line(frame, p1, p2, Scalar(0, 0, 255), 1, 8);
+            line(frame, p1, p2, Scalar(0, 0, 255), 1, LINE_AA);
 #endif //GRAPHIC
             continue;
         }
@@ -111,7 +111,7 @@ void filterLinesWithAdaptiveROI(InputOutputArray frame, const std::vector<Vec4i>
         pos = m < 0 ? 0 : 1;  // 왼쪽, 오른쪽 결정
 
         // 프레임에 표기 (초록색)
-        line(frame, p1, p2, Scalar(0, 255, 0), 1, 8);
+        line(frame, p1, p2, Scalar(0, 255, 0), 1, LINE_AA);
 
         // 제곱 합
         int power_sum = pow((current_x_bottom - lane[pos].x_bottom), 2) + pow((current_x_top - lane[pos].x_top), 2);
@@ -137,7 +137,7 @@ void filterLinesWithAdaptiveROI(InputOutputArray frame, const std::vector<Vec4i>
 
             // 기존 값으로 차로 표기
             Line_info prev = roi.line_info[i].line;
-            line(frame, {prev.x_bottom, DEFAULT_ROI_HEIGHT}, {prev.x_top, 0}, Scalar(255, 0, 0), 1, 8);
+            line(frame, {prev.x_bottom, DEFAULT_ROI_HEIGHT}, {prev.x_top, 0}, Scalar(255, 0, 0), 1, LINE_AA);
         } else {
             // 차선 검출 성공
             Point p1(lines[lane[i].idx][0], lines[lane[i].idx][1]), p2(lines[lane[i].idx][2], lines[lane[i].idx][3]);
@@ -156,7 +156,7 @@ void filterLinesWithAdaptiveROI(InputOutputArray frame, const std::vector<Vec4i>
                 if ((x1 >= prev[i].x_bottom + DX - 3 || x1 <= prev[i].x_bottom - DX + 3) &&
                     (x2 >= prev[i].x_top + DX - 3 || x2 <= prev[i].x_top - DX + 3)) {
                     // 노란색으로 표시
-                    line(frame, p1, p2, Scalar(0, 255, 255), 3, 8);
+                    line(frame, p1, p2, Scalar(0, 255, 255), 3, LINE_AA);
                     // ROI 초기화, 정적 ROI 적용
                     roi.line_info[i].reset();
                     roi.initROI(i);
@@ -169,7 +169,7 @@ void filterLinesWithAdaptiveROI(InputOutputArray frame, const std::vector<Vec4i>
             }
 
             // 파란색으로 표기
-            line(frame, p1, p2, Scalar(255, 0, 0), 1, 8);
+            line(frame, p1, p2, Scalar(255, 0, 0), 1, LINE_AA);
             roi.line_info[i].update_lines(p1, p2, getCotangent(p1, p2));
         }
     }

--- a/wrap-up/ver3.0/main.cpp
+++ b/wrap-up/ver3.0/main.cpp
@@ -1,0 +1,308 @@
+#include <iostream>
+#include "opencv2/opencv.hpp"
+#include "./ROI.hpp"
+
+ROI roi;
+
+#ifdef TIME_TEST
+
+#include "../profile/timeLapse.hpp"
+
+TimeLapse tl(6); // 시간 측정
+
+#endif //TIME_TEST
+#ifdef DETECTION_RATE
+int detected[3], frame_cnt;
+#endif //DETECTION_RATE
+#ifdef VIDEO_SAVE
+
+#include "../profile/oneVideoWriter.hpp"
+
+OneVideoWriter vw;
+#endif //VIDEO_SAVE
+using namespace std;
+using namespace cv;
+
+const string SRC_PREFIX = "../../video/";
+
+#ifdef SHOW
+
+// 디버깅 용 이미지 출력 함수
+void showImage(const string &label, InputArray img, int t = 0, int x = 0, int y = 0) {
+    namedWindow(label, 1);
+    moveWindow(label, x, y);
+    imshow(label, img);
+    waitKey(t);
+}
+
+#endif //SHOW
+
+/**
+ * 기울기 역수 구하는 함수 (cotangent)
+ * @param p1 점 1
+ * @param p2 점 2
+ * @return 기울기
+ */
+double getCotangent(Point p1, Point p2) {
+    return (double) (p1.x - p2.x) / (p1.y - p2.y);
+}
+
+/**
+ * 프레임에 선분 그리는 함수
+ * @param frame 배경 프레임 (원본)
+ * @param lines 그릴 선분들
+ * @param color 색
+ */
+void drawLines(InputOutputArray frame, const std::vector <Vec4i> &lines, Scalar color = Scalar(0, 255, 0)) {
+    for (Vec4i pts: lines) {
+        Point p1(pts[0], pts[1]), p2(pts[2], pts[3]);
+        line(frame, p1, p2, color, 1, 8);
+    }
+}
+
+/**
+ * 허프 변환으로 검출한 차선 필터링
+ * @param frame
+ * @param lines
+ */
+void filterLinesWithAdaptiveROI(InputOutputArray frame, const std::vector <Vec4i> &lines) {
+    struct Data {
+        double grad, diff;
+        int idx;
+    };
+
+    Data lane[2]; // 왼쪽[0], 오른쪽[1] 차선
+
+    // 초기화
+    for (int i = 0; i < 2; i++) {
+        lane[i].grad = roi.line_info[i].adaptive_ROI_flag ? roi.line_info[i].line.gradient : 0;
+        lane[i].diff = 2.0;
+        lane[i].idx = -1;
+    }
+
+    int idx = -1, pos; // 선분 index, pos: 왼쪽 or 오른쪽
+    double m;
+
+    for (Vec4i pts: lines) {
+        idx++;
+
+        Point p1(pts[0], pts[1]), p2(pts[2], pts[3]);
+
+        m = getCotangent(p1, p2);
+
+        if (abs(m) > GRADIENT_STD) { // 기준 기울기보다 작은 경우 (역수로 계산하므로 부등호 반대)
+#ifdef GRAPHIC
+            line(frame, p1, p2, Scalar(0, 0, 255), 1, 8);
+#endif //GRAPHIC
+            continue;
+        }
+
+        pos = m < 0 ? 0 : 1; // 왼쪽, 오른쪽 결정
+
+        // 기존 값과 차이가 최소인 선분 필터링
+        if (abs(lane[pos].grad - m) < lane[pos].diff) {
+            lane[pos].diff = abs(lane[pos].grad - m);
+            lane[pos].idx = idx;
+        }
+
+        // 프레임에 표기 (붉은색)
+        line(frame, p1, p2, Scalar(0, 255, 0), 1, 8);
+    }
+
+    // 검출한 선분 update
+    for (int i = 0; i < 2; i++) {
+        if (lane[i].idx == -1) {
+            roi.line_info[i].not_found();
+
+            // 동적 roi...
+            if (!roi.line_info[i].adaptive_ROI_flag) {
+                continue;
+            }
+
+            // 기존 값으로 차로 표기
+            Line_info prev = roi.line_info[i].line;
+            line(frame, {prev.x_bottom, DEFAULT_ROI_HEIGHT}, {prev.x_top, 0}, Scalar(255, 0, 0), 1, 8);
+        } else {
+            // 차선 검출 성공
+            Point p1(lines[lane[i].idx][0], lines[lane[i].idx][1]), p2(lines[lane[i].idx][2], lines[lane[i].idx][3]);
+            // 파란색으로 표기
+            line(frame, p1, p2, Scalar(255, 0, 0), 1, 8);
+            roi.line_info[i].update_lines(p1, p2, getCotangent(p1, p2));
+        }
+    }
+#ifdef DETECTION_RATE
+    // 검출 -> 동적 roi가 작동 중이거나 혹은 idx =! -1 인 경우
+    // 미검출 -> 동적 roi가 미작동이면서 idx==-1 인 경우
+    bool left = roi.line_info[0].adaptive_ROI_flag || (lane[0].idx != -1);
+    bool right = roi.line_info[1].adaptive_ROI_flag || (lane[1].idx != -1);
+
+    if (left && right) detected[2]++;
+    else if (left || right) detected[1]++;
+    else detected[0]++;
+
+    frame_cnt++;
+#endif //DETECTION_RATE
+    roi.updateROI();
+}
+
+void test(InputArray frame) {
+#ifdef TIME_TEST
+    tl.restart(); // 타이머 재설정
+#endif //TIME_TEST
+    Mat road_area = frame.getMat()(Range(DEFAULT_ROI_UP, DEFAULT_ROI_DOWN), Range(DEFAULT_ROI_LEFT, DEFAULT_ROI_RIGHT));
+    // 0. to grayscale
+    Mat grayscaled;
+    cvtColor(road_area, grayscaled, COLOR_BGR2GRAY);
+
+#ifdef SHOW
+    showImage("gray", grayscaled, 5);
+    Mat show_roi = grayscaled.clone(); // roi 마스킹 화면 출력용
+#endif // SHOW
+#ifdef VIDEO_SAVE
+    vw.writeFrame(grayscaled, 0);
+    Mat show_roi = grayscaled.clone(); // roi 마스킹 화면 출력용
+#endif //VIDEO_SAVE
+
+#ifdef TIME_TEST
+    tl.proc_record(grayscaled); // 0. to grayscale
+#endif // TIME_TEST
+
+    // 1. 주어진 임계값(default:130)으로 이진화
+    threshold(grayscaled, grayscaled, 150, 145, THRESH_BINARY);
+
+#ifdef TIME_TEST
+    tl.proc_record(grayscaled); // 1. 주어진 임계값(default:130)으로 이진화
+#endif //TIME_TEST
+
+    // 2. apply roi
+    Mat roi_applied;
+    roi.applyROI(grayscaled, roi_applied);
+
+#ifdef SHOW
+    roi.applyROI(show_roi, show_roi); // roi 화면 출력용
+    showImage("roi", show_roi, 5, FRAME_WIDTH);
+#endif // SHOW
+#ifdef VIDEO_SAVE
+    roi.applyROI(show_roi, show_roi);
+    vw.writeFrame(show_roi, 1);
+#endif //VIDEO_SAVE
+
+#ifdef TIME_TEST
+    tl.proc_record(roi_applied); // 2. apply roi
+#endif // TIME_TEST
+
+    // 3. canny
+    Mat edge;
+    Canny(roi_applied, edge, 50, 150);
+
+#ifdef SHOW
+    showImage("edge", edge, 5, 0, FRAME_HEIGHT);
+#endif // SHOW
+#ifdef VIDEO_SAVE
+    vw.writeFrame(edge, 2);
+#endif //VIDEO_SAVE
+#ifdef TIME_TEST
+    tl.proc_record(edge); // 3. canny
+#endif // TIME_TEST
+
+    // 4. hough line
+    std::vector <Vec4i> lines;
+    HoughLinesP(edge, lines, 1, CV_PI / 180, 30, 40, 40);
+
+#ifdef TIME_TEST
+    tl.stop_both_timer();
+    Mat preview_lines = frame.getMat().clone(); // 필터링 전 검출한 선분 그리기
+    drawLines(preview_lines, lines);
+
+    tl.proc_record(preview_lines); // 4. hough line
+#endif //TIME_TEST
+
+    // 5. filter lines
+    Mat result = road_area.clone();
+    filterLinesWithAdaptiveROI(result, lines);
+
+#ifdef SHOW
+    showImage("result", result, 5, FRAME_WIDTH, FRAME_HEIGHT);
+//    waitKey(0);
+#endif // SHOW
+
+#ifdef TIME_TEST
+    tl.proc_record(result); // 5. filter lines
+    tl.total_record(frame.getMat(), result); // 6. total
+#endif // TIME_TEST
+#ifdef VIDEO_SAVE
+    vw.writeFrame(result, 3);
+#endif //VIDEO_SAVE
+}
+
+void videoHandler(const string &file_name) {
+    VideoCapture video(file_name);
+
+    if (!video.isOpened()) {
+        cout << "Can't open video\n";
+        return;
+    }
+
+    roi = ROI();
+
+    Mat frame;
+
+    while (true) {
+        video >> frame;
+
+        if (frame.empty()) {
+            break;
+        }
+#ifdef TIME_TEST
+        tl.prev_img = frame.clone(); // 처리 전 원본 사진 저장
+#endif //TIME_TEST
+        test(frame);
+    }
+
+    video.release();
+}
+
+
+int main(int argc, char *argv[]) {
+    vector <string> file_list;
+    glob(SRC_PREFIX + "*.avi", file_list);
+
+    if (file_list.empty()) {
+        cout << "can't find image list\n";
+        return 1;
+    }
+
+    for (string &file_name: file_list) {
+#ifdef TIME_TEST
+        tl = TimeLapse(6);
+        tl.set_tc(1);
+//        tl.set_tc(stoi(argv[1]));
+#endif // TIME_TEST
+#ifdef VIDEO_SAVE
+        auto pos = file_name.rfind('.');
+        string save_path = "../result/video/" + file_name.substr(pos - 2, 2) + ".mp4";
+        vw = OneVideoWriter(save_path, DEFAULT_ROI_WIDTH, DEFAULT_ROI_HEIGHT, 2, 2, 4);
+#endif //VIDEO_SAVE
+#ifdef DETECTION_RATE
+        for (int i = 0; i < 3; i++) {
+            detected[i] = 0;
+        }
+        frame_cnt = 0;
+#endif //DETECTION_RATE
+#ifdef SHOW
+        if (file_name == SRC_PREFIX + "2.avi") continue;
+#endif //SHOW
+        videoHandler(file_name);
+
+#ifdef TIME_TEST
+        tl.print_info_all();
+#endif //TIME_TEST
+#ifdef DETECTION_RATE
+        for (int i = 0; i < 3; i++) {
+            cout << detected[i] << ',';
+        }
+        cout << frame_cnt << '\n';
+#endif //DETECTION_RATE
+    }
+    return 0;
+}

--- a/wrap-up/ver3.0/main.cpp
+++ b/wrap-up/ver3.0/main.cpp
@@ -263,7 +263,7 @@ void test(InputArray frame) {
 
     // 4. hough line
     std::vector<Vec4i> lines;
-    HoughLinesP(edge, lines, 1, CV_PI / 180, 30, 40, 40);
+    HoughLinesP(edge, lines, 1, CV_PI / 180, HOUGH_PARAM1, HOUGH_PARAM2, HOUGH_PARAM3);
 
 #ifdef TIME_TEST
     tl.stop_both_timer();

--- a/wrap-up/ver3.0/main.cpp
+++ b/wrap-up/ver3.0/main.cpp
@@ -69,17 +69,20 @@ void drawLines(InputOutputArray frame, const std::vector <Vec4i> &lines, Scalar 
  */
 void filterLinesWithAdaptiveROI(InputOutputArray frame, const std::vector <Vec4i> &lines) {
     struct Data {
-        double grad, diff;
-        int idx;
+        int idx, x_bottom, x_top, diff;
     };
 
     Data lane[2]; // 왼쪽[0], 오른쪽[1] 차선
 
     // 초기화
     for (int i = 0; i < 2; i++) {
-        lane[i].grad = roi.line_info[i].adaptive_ROI_flag ? roi.line_info[i].line.gradient : 0;
-        lane[i].diff = 2.0;
+        lane[i].x_bottom = roi.line_info[i].adaptive_ROI_flag ? roi.line_info[i].line.x_bottom : 0;
+        lane[i].x_top = roi.line_info[i].adaptive_ROI_flag ? roi.line_info[i].line.x_top : 0;
+        lane[i].diff = INT_MAX;
         lane[i].idx = -1;
+
+        // ROI 기준 선 빨간색으로 표시
+        line(frame, {lane[i].x_top, 0}, {lane[i].x_bottom, DEFAULT_ROI_HEIGHT}, Scalar(0, 0, 255), 3, 8);
     }
 
     int idx = -1, pos; // 선분 index, pos: 왼쪽 or 오른쪽
@@ -99,16 +102,25 @@ void filterLinesWithAdaptiveROI(InputOutputArray frame, const std::vector <Vec4i
             continue;
         }
 
-        pos = m < 0 ? 0 : 1; // 왼쪽, 오른쪽 결정
+        int current_x_bottom =
+                (p1.x * (p2.y - DEFAULT_ROI_HEIGHT) - p2.x * (p1.y - DEFAULT_ROI_HEIGHT)) / (p2.y - p1.y);
+        int current_x_top = current_x_bottom - DEFAULT_ROI_HEIGHT * m;
 
-        // 기존 값과 차이가 최소인 선분 필터링
-        if (abs(lane[pos].grad - m) < lane[pos].diff) {
-            lane[pos].diff = abs(lane[pos].grad - m);
+        pos = m < 0 ? 0 : 1;  // 왼쪽, 오른쪽 결정
+
+        // 프레임에 표기 (초록색)
+        line(frame, p1, p2, Scalar(0, 255, 0), 1, 8);
+
+        // 제곱 합
+        int power_sum = pow((current_x_bottom - lane[pos].x_bottom), 2) + pow((current_x_top - lane[pos].x_top), 2);
+
+        // 기존 제곱 합과 차이가 최소인 선분
+        if (power_sum < lane[pos].diff) {
+//            cout << lane[pos].x_bottom << " " << lane[pos].x_top << " " << current_x_bottom << " " << current_x_top
+//                 << " " << power_sum << endl;
+            lane[pos].diff = power_sum;
             lane[pos].idx = idx;
         }
-
-        // 프레임에 표기 (붉은색)
-        line(frame, p1, p2, Scalar(0, 255, 0), 1, 8);
     }
 
     // 검출한 선분 update
@@ -127,6 +139,33 @@ void filterLinesWithAdaptiveROI(InputOutputArray frame, const std::vector <Vec4i
         } else {
             // 차선 검출 성공
             Point p1(lines[lane[i].idx][0], lines[lane[i].idx][1]), p2(lines[lane[i].idx][2], lines[lane[i].idx][3]);
+
+            // 동적 ROI 기준선 정보
+            Line_info prev[2];
+            prev[0] = roi.line_info[0].line;
+            prev[1] = roi.line_info[1].line;
+
+            // 현재 프레임의 최종 차선 위치 정보
+            int x1 = (p1.x * (p2.y - DEFAULT_ROI_HEIGHT) - p2.x * (p1.y - DEFAULT_ROI_HEIGHT)) / (p2.y - p1.y);
+            int x2 = x1 - DEFAULT_ROI_HEIGHT * m;
+
+            if (roi.line_info[i].adaptive_ROI_flag) {
+                // ROI 테두리 기준 3픽셀 이내에 선이 존재하면 ROI 리셋
+                if ((x1 >= prev[i].x_bottom + DX - 3 || x1 <= prev[i].x_bottom - DX + 3) &&
+                    (x2 >= prev[i].x_top + DX - 3 || x2 <= prev[i].x_top - DX + 3)) {
+                    // 노란색으로 표시
+                    line(frame, p1, p2, Scalar(0, 255, 255), 3, 8);
+                    // ROI 초기화, 정적 ROI 적용
+                    roi.line_info[i].reset();
+                    roi.initROI(i);
+
+                    // 이진화 임계치 업데이트
+                    adaptiveThresh.thresh += 5;
+
+                    continue;
+                }
+            }
+
             // 파란색으로 표기
             line(frame, p1, p2, Scalar(255, 0, 0), 1, 8);
             roi.line_info[i].update_lines(p1, p2, getCotangent(p1, p2));


### PR DESCRIPTION
ver 2.2 마지막 업데이트 -> roi 초반부터 좁히기 때문에 시간이 많이 개선되어서 이진화에 시간을 조금 더 쓸 수 있다는 판단으로 우선은 매 프레임마다 이진화 픽셀 카운트를 해서 결과 값을 반영하도록 했습니다.

[이진화 분석](https://docs.google.com/spreadsheets/d/1GdGrRFsMzpVa8K67jBmcZ_Bh8wQg_sMZkG8-tfVSdAA/edit#gid=372246385)
[이진화 분석 영상](https://iewha-my.sharepoint.com/:f:/g/personal/jiyoung_06_i_ewha_ac_kr/ElIQZl-3XVFPmXXU7lBnWlABZCZusQCbFZuMYidmfuxd2w?e=yqJ5gk)

일반적으로 정상 프레임일 때는 1 후반 ~ 3% 정도 나오는 것을 확인 후 우선 경계를 1%와 5%로 잡았습니다.
여전히 라즈베리파이 상에서 프레임 당 평균 6 ~ 8ms 나오는 것 확인해서 시간 여유가 있으니까 좌우 분리한 버전으로 마이너 업데이트 해볼만 한거 같아요.